### PR TITLE
CTCP-4611: Reading from the yes/no page when adding transport charges at consignment level

### DIFF
--- a/app/models/journeyDomain/item/ItemDomain.scala
+++ b/app/models/journeyDomain/item/ItemDomain.scala
@@ -20,11 +20,10 @@ import cats.data.Kleisli
 import cats.implicits._
 import config.Constants.CountryCode._
 import config.Constants.DeclarationType._
-import config.Constants.SecurityType._
 import config.PhaseConfig
 import models.DeclarationTypeItemLevel._
 import models.DocumentType.{Previous, Transport}
-import models.Phase.{PostTransition, Transition}
+import models.Phase.PostTransition
 import models._
 import models.journeyDomain.item.additionalInformation.AdditionalInformationListDomain
 import models.journeyDomain.item.additionalReferences.AdditionalReferencesDomain
@@ -279,16 +278,18 @@ object ItemDomain {
       .filterOptionalDependent(identity)(AdditionalInformationListDomain.userAnswersReader(itemIndex))
 
   def transportChargesReader(itemIndex: Index)(implicit phaseConfig: PhaseConfig): UserAnswersReader[Option[TransportChargesMethodOfPayment]] =
-    for {
-      securityDetails                      <- SecurityDetailsTypePage.reader
-      isConsignmentTransportChargesDefined <- ConsignmentTransportChargesPage.isDefined
-      result <- {
-        (securityDetails, isConsignmentTransportChargesDefined, phaseConfig.phase) match {
-          case (NoSecurityDetails, _, Transition) | (_, false, Transition) =>
-            AddTransportChargesYesNoPage(itemIndex).filterOptionalDependent(identity)(TransportChargesMethodOfPaymentPage(itemIndex).reader)
-          case _ => UserAnswersReader(None)
+    phaseConfig.phase match {
+      case Phase.Transition =>
+        AddConsignmentTransportChargesYesNoPage.optionalReader.map(_.contains(true)).flatMap {
+          case false =>
+            AddTransportChargesYesNoPage(itemIndex).filterOptionalDependent(identity) {
+              TransportChargesMethodOfPaymentPage(itemIndex).reader
+            }
+          case true =>
+            none[TransportChargesMethodOfPayment].pure[UserAnswersReader]
         }
-      }
-    } yield result
+      case Phase.PostTransition =>
+        none[TransportChargesMethodOfPayment].pure[UserAnswersReader]
+    }
 
 }

--- a/app/models/journeyDomain/item/ItemDomain.scala
+++ b/app/models/journeyDomain/item/ItemDomain.scala
@@ -43,7 +43,7 @@ import models.journeyDomain.{
 import models.reference.{Country, TransportChargesMethodOfPayment}
 import pages.external._
 import pages.item._
-import pages.sections.external.{ConsignmentConsigneeSection, DocumentsSection, TransportEquipmentsSection}
+import pages.sections.external.{DocumentsSection, TransportEquipmentsSection}
 import play.api.i18n.Messages
 import play.api.mvc.Call
 
@@ -218,11 +218,11 @@ object ItemDomain {
     phaseConfig.phase match {
       case Phase.Transition =>
         for {
-          consignmentConsigneePresent <- ConsignmentConsigneeSection.isDefined
+          moreThanOneConsignee        <- MoreThanOneConsigneePage.optionalReader.map(_.contains(true))
           countryOfDestinationInCL009 <- ConsignmentCountryOfDestinationInCL009Page.readerWithDefault(false)
-          reader <- (consignmentConsigneePresent, countryOfDestinationInCL009) match {
-            case (true, true) => none[ConsigneeDomain].pure[UserAnswersReader]
-            case _            => ConsigneeDomain.userAnswersReader(itemIndex).map(Some(_))
+          reader <- (moreThanOneConsignee, countryOfDestinationInCL009) match {
+            case (false, true) => none[ConsigneeDomain].pure[UserAnswersReader]
+            case _             => ConsigneeDomain.userAnswersReader(itemIndex).map(Some(_))
           }
         } yield reader
       case Phase.PostTransition =>

--- a/app/pages/external/AddConsignmentTransportChargesYesNoPage.scala
+++ b/app/pages/external/AddConsignmentTransportChargesYesNoPage.scala
@@ -19,7 +19,7 @@ package pages.external
 import pages.{equipmentAndChargesPath, ReadOnlyPage}
 import play.api.libs.json.JsPath
 
-case object ConsignmentTransportChargesPage extends ReadOnlyPage[String] {
+case object AddConsignmentTransportChargesYesNoPage extends ReadOnlyPage[Boolean] {
 
-  override def path: JsPath = equipmentAndChargesPath \ "paymentMethod" \ "method"
+  override def path: JsPath = equipmentAndChargesPath \ "addPaymentMethodYesNo"
 }

--- a/app/pages/external/MoreThanOneConsigneePage.scala
+++ b/app/pages/external/MoreThanOneConsigneePage.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package pages.sections.external
+package pages.external
 
-import pages.consignmentPath
-import pages.sections.ReadOnlySection
-import play.api.libs.json.{JsObject, JsPath}
+import pages.{consignmentPath, ReadOnlyPage}
+import play.api.libs.json.JsPath
 
-object ConsignmentConsigneeSection extends ReadOnlySection[JsObject] {
+object MoreThanOneConsigneePage extends ReadOnlyPage[Boolean] {
 
-  override def path: JsPath = consignmentPath \ "consignee"
+  override def path: JsPath = consignmentPath \ "moreThanOneConsignee"
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -88,6 +88,9 @@ trait SpecBase
           jsValue => userAnswers.copy(data = jsValue)
         )
 
+    def setValue[T](page: ReadOnlyPage[T], value: Option[T])(implicit format: Format[T]): UserAnswers =
+      value.map(setValue(page, _)).getOrElse(userAnswers)
+
     def setValue[T](page: QuestionPage[T], value: Option[T])(implicit format: Format[T]): UserAnswers =
       value.map(setValue(page, _)).getOrElse(userAnswers)
 

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -37,7 +37,6 @@ trait UserAnswersEntryGenerators {
 
   private def generateExternalAnswer: PartialFunction[Gettable[_], Gen[JsValue]] = {
     import pages.external._
-    import pages.sections.external._
     {
       case CustomsOfficeOfDeparturePage               => Gen.alphaNumStr.map(JsString)
       case CustomsOfficeOfDepartureInCL112Page        => arbitrary[Boolean].map(JsBoolean)
@@ -48,8 +47,9 @@ trait UserAnswersEntryGenerators {
       case ConsignmentCountryOfDestinationPage        => arbitrary[Country].map(Json.toJson(_))
       case ApprovedOperatorPage                       => arbitrary[Boolean].map(JsBoolean)
       case SecurityDetailsTypePage                    => arbitrary[String](arbitrarySecurityDetailsType).map(Json.toJson(_))
-      case ConsignmentConsigneeSection                => arbitrary[JsObject]
+      case MoreThanOneConsigneePage                   => arbitrary[JsObject]
       case ConsignmentCountryOfDestinationInCL009Page => arbitrary[Boolean].map(JsBoolean)
+      case AddConsignmentTransportChargesYesNoPage    => arbitrary[Boolean].map(JsBoolean)
     }
   }
 

--- a/test/models/journeyDomain/item/ItemDomainSpec.scala
+++ b/test/models/journeyDomain/item/ItemDomainSpec.scala
@@ -42,7 +42,7 @@ import pages.item.additionalReference.index._
 import pages.item.dangerousGoods.index.UNNumberPage
 import pages.item.documents.index.DocumentPage
 import pages.item.packages.index._
-import pages.sections.external.{ConsignmentConsigneeSection, DocumentsSection, TransportEquipmentsSection}
+import pages.sections.external.{DocumentsSection, TransportEquipmentsSection}
 import play.api.libs.json.{JsArray, Json}
 
 import java.util.UUID
@@ -1329,50 +1329,59 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
         "and consignee info present at consignment level" - {
           "and country of destination is in set CL009" - {
             "then result must not be defined" in {
-              val initialAnswers = emptyUserAnswers
-                .setValue(ConsignmentConsigneeSection, Json.obj("foo" -> "bar"))
-                .setValue(ConsignmentCountryOfDestinationInCL009Page, true)
+              forAll(Gen.oneOf(Some(false), None)) {
+                falseOrUndefined =>
+                  val initialAnswers = emptyUserAnswers
+                    .setValue(MoreThanOneConsigneePage, falseOrUndefined)
+                    .setValue(ConsignmentCountryOfDestinationInCL009Page, true)
 
-              forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
-                userAnswers =>
-                  val result = UserAnswersReader[Option[ConsigneeDomain]](
-                    ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
-                  ).run(userAnswers)
+                  forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
+                    userAnswers =>
+                      val result = UserAnswersReader[Option[ConsigneeDomain]](
+                        ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
+                      ).run(userAnswers)
 
-                  result.value must not be defined
+                      result.value must not be defined
+                  }
               }
             }
           }
 
           "and country of destination is not in set CL009" - {
             "then result must be defined" in {
-              val initialAnswers = emptyUserAnswers
-                .setValue(ConsignmentConsigneeSection, Json.obj("foo" -> "bar"))
-                .setValue(ConsignmentCountryOfDestinationInCL009Page, false)
+              forAll(Gen.oneOf(Some(false), None)) {
+                falseOrUndefined =>
+                  val initialAnswers = emptyUserAnswers
+                    .setValue(MoreThanOneConsigneePage, falseOrUndefined)
+                    .setValue(ConsignmentCountryOfDestinationInCL009Page, false)
 
-              forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
-                userAnswers =>
-                  val result = UserAnswersReader[Option[ConsigneeDomain]](
-                    ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
-                  ).run(userAnswers)
+                  forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
+                    userAnswers =>
+                      val result = UserAnswersReader[Option[ConsigneeDomain]](
+                        ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
+                      ).run(userAnswers)
 
-                  result.value must be(defined)
+                      result.value must be(defined)
+                  }
               }
             }
           }
 
           "and country of destination is undefined" - {
             "then result must be defined" in {
-              val initialAnswers = emptyUserAnswers
-                .setValue(ConsignmentConsigneeSection, Json.obj("foo" -> "bar"))
+              forAll(Gen.oneOf(Some(false), None)) {
+                falseOrUndefined =>
+                  val initialAnswers = emptyUserAnswers
+                    .setValue(MoreThanOneConsigneePage, falseOrUndefined)
 
-              forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
-                userAnswers =>
-                  val result = UserAnswersReader[Option[ConsigneeDomain]](
-                    ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
-                  ).run(userAnswers)
+                  forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
+                    userAnswers =>
+                      val result = UserAnswersReader[Option[ConsigneeDomain]](
+                        ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)
+                      ).run(userAnswers)
 
-                  result.value must be(defined)
+                      result.value must be(defined)
+                  }
               }
             }
           }
@@ -1382,6 +1391,7 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
           "and country of destination is in set CL009" - {
             "then result must be defined" in {
               val initialAnswers = emptyUserAnswers
+                .setValue(MoreThanOneConsigneePage, true)
                 .setValue(ConsignmentCountryOfDestinationInCL009Page, true)
 
               forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
@@ -1398,6 +1408,7 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
           "and country of destination is not in set CL009" - {
             "then result must be defined" in {
               val initialAnswers = emptyUserAnswers
+                .setValue(MoreThanOneConsigneePage, true)
                 .setValue(ConsignmentCountryOfDestinationInCL009Page, false)
 
               forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
@@ -1413,7 +1424,10 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
 
           "and country of destination is undefined" - {
             "then result must be defined" in {
-              forAll(arbitraryConsigneeAnswers(emptyUserAnswers, itemIndex)) {
+              val initialAnswers = emptyUserAnswers
+                .setValue(MoreThanOneConsigneePage, true)
+
+              forAll(arbitraryConsigneeAnswers(initialAnswers, itemIndex)) {
                 userAnswers =>
                   val result = UserAnswersReader[Option[ConsigneeDomain]](
                     ItemDomain.consigneeReader(itemIndex)(mockPhaseConfig)

--- a/test/models/journeyDomain/item/ItemDomainSpec.scala
+++ b/test/models/journeyDomain/item/ItemDomainSpec.scala
@@ -2129,12 +2129,12 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
         }
 
         "when in transition" - {
-          "and security is 0" - {
-            "and add transport charges is answered yes" in {
-              forAll(arbitrary[TransportChargesMethodOfPayment](arbitraryMethodOfPayment)) {
-                transportCharge =>
+          "and add consignment transport charges is false or undefined" - {
+            "and add item transport charges is answered yes" in {
+              forAll(Gen.oneOf(Some(false), None), arbitrary[TransportChargesMethodOfPayment](arbitraryMethodOfPayment)) {
+                (falseOrUndefined, transportCharge) =>
                   val userAnswers = emptyUserAnswers
-                    .setValue(SecurityDetailsTypePage, NoSecurityDetails)
+                    .setValue(AddConsignmentTransportChargesYesNoPage, falseOrUndefined)
                     .setValue(AddTransportChargesYesNoPage(itemIndex), true)
                     .setValue(TransportChargesMethodOfPaymentPage(itemIndex), transportCharge)
 
@@ -2148,89 +2148,63 @@ class ItemDomainSpec extends SpecBase with ScalaCheckPropertyChecks with Generat
               }
             }
 
-            "and add transport charges is answered no" in {
-              val userAnswers = emptyUserAnswers
-                .setValue(SecurityDetailsTypePage, NoSecurityDetails)
-                .setValue(AddTransportChargesYesNoPage(itemIndex), false)
+            "and add item transport charges is answered no" in {
+              forAll(Gen.oneOf(Some(false), None)) {
+                falseOrUndefined =>
+                  val userAnswers = emptyUserAnswers
+                    .setValue(AddConsignmentTransportChargesYesNoPage, falseOrUndefined)
+                    .setValue(AddTransportChargesYesNoPage(itemIndex), false)
 
-              val expectedResult = None
+                  val expectedResult = None
 
-              val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
-                ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
-              ).run(userAnswers)
+                  val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
+                    ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
+                  ).run(userAnswers)
 
-              result.value mustBe expectedResult
+                  result.value mustBe expectedResult
+              }
             }
           }
 
-          "or if consignmentTransportCharges is not present" in {
-            forAll(arbitrary[String](arbitrarySecurityDetailsType), arbitrary[TransportChargesMethodOfPayment]) {
-              (securityDetailType, transportCharges) =>
-                val userAnswers = emptyUserAnswers
-                  .setValue(SecurityDetailsTypePage, securityDetailType)
-                  .setValue(AddTransportChargesYesNoPage(itemIndex), true)
-                  .setValue(TransportChargesMethodOfPaymentPage(itemIndex), transportCharges)
+          "and add consignment transport charges is true" in {
+            val userAnswers = emptyUserAnswers
+              .setValue(AddConsignmentTransportChargesYesNoPage, true)
 
-                val expectedResult = Some(transportCharges)
+            val expectedResult = None
 
-                val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
-                  ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
-                ).run(userAnswers)
+            val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
+              ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
+            ).run(userAnswers)
 
-                result.value mustBe expectedResult
-
-            }
-
+            result.value mustBe expectedResult
           }
-
-          "or if consignmentTransportCharges is present" in {
-            forAll(arbitrary[String](arbitrarySomeSecurityDetailsType), nonEmptyString) {
-              (securityDetailType, consignmentTransportCharges) =>
-                val userAnswers = emptyUserAnswers
-                  .setValue(SecurityDetailsTypePage, securityDetailType)
-                  .setValue(ConsignmentTransportChargesPage, consignmentTransportCharges)
-
-                val expectedResult = None
-
-                val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
-                  ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
-                ).run(userAnswers)
-
-                result.value mustBe expectedResult
-
-            }
-
-          }
-
         }
-
       }
     }
 
     "can not be read from user answers" - {
       "when in transition" - {
-        "and security is 0" - {
-          "and add transport charges is unanswered" in {
-            val userAnswers = emptyUserAnswers
-              .setValue(SecurityDetailsTypePage, NoSecurityDetails)
+        "and add transport charges is unanswered" in {
+          val userAnswers = emptyUserAnswers
+            .setValue(SecurityDetailsTypePage, NoSecurityDetails)
 
-            val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
-              ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
-            ).run(userAnswers)
+          val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
+            ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
+          ).run(userAnswers)
 
-            result.left.value.page mustBe AddTransportChargesYesNoPage(itemIndex)
-          }
-          "and transport charges is unanswered" in {
-            val userAnswers = emptyUserAnswers
-              .setValue(SecurityDetailsTypePage, NoSecurityDetails)
-              .setValue(AddTransportChargesYesNoPage(itemIndex), true)
+          result.left.value.page mustBe AddTransportChargesYesNoPage(itemIndex)
+        }
 
-            val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
-              ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
-            ).run(userAnswers)
+        "and transport charges is unanswered" in {
+          val userAnswers = emptyUserAnswers
+            .setValue(SecurityDetailsTypePage, NoSecurityDetails)
+            .setValue(AddTransportChargesYesNoPage(itemIndex), true)
 
-            result.left.value.page mustBe TransportChargesMethodOfPaymentPage(itemIndex)
-          }
+          val result: EitherType[Option[TransportChargesMethodOfPayment]] = UserAnswersReader[Option[TransportChargesMethodOfPayment]](
+            ItemDomain.transportChargesReader(itemIndex)(mockTransitionPhaseConfig)
+          ).run(userAnswers)
+
+          result.left.value.page mustBe TransportChargesMethodOfPaymentPage(itemIndex)
         }
       }
     }


### PR DESCRIPTION
Here is the bug that was happening:

1. Set `equipmentAndChargesPath \ "addPaymentMethodYesNo"` to `false`
2. Go through items journey and add transport charges
3. Go back to transport details and set `equipmentAndChargesPath \ "addPaymentMethodYesNo"` to `true`
4. Items user answers reader checks for presence of value in `equipmentAndChargesPath \ "paymentMethod" \ "method"`. There isn't one so thinks items is in progress. Status gets set to In Progress.
5. We add a payment method for consignment transport charges
6. Go to task list - items has been set to in progress
7. Go into items, user answers reader sees that `equipmentAndChargesPath \ "paymentMethod" \ "method"` has now been populated so recognises that items is Completed, but status is stuck In Progress

We can fix this by instead checking to see if `equipmentAndChargesPath \ "addPaymentMethodYesNo"` is true. This is an optional field so the flip-side is that it is false or undefined.

The other change here is to remove the security check for the transport details nav logic. This is a duplication of the logic that is done in transport details so isn't required here.