### PR TITLE
CTCP-5134: Post transition -  implement CL234 - reject additionalReferenceNumber value 0

### DIFF
--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -94,6 +94,16 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
       .execute[NonEmptySet[AdditionalReference]]
   }
 
+  def getDocumentTypeExcise(docType: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[DocTypeExcise] = {
+    val url = url"${config.referenceDataUrl}/lists/DocumentTypeExcise"
+    http
+      .get(url)
+      .transform(_.withQueryStringParameters("data.code" -> docType))
+      .setHeader(version2Header: _*)
+      .execute[NonEmptySet[DocTypeExcise]]
+      .map(_.head)
+  }
+
   def getCUSCode(cusCode: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CUSCode] = {
     val url = url"${config.referenceDataUrl}/lists/CUSCode"
     http

--- a/app/controllers/item/additionalReference/index/AdditionalReferenceController.scala
+++ b/app/controllers/item/additionalReference/index/AdditionalReferenceController.scala
@@ -59,7 +59,6 @@ class AdditionalReferenceController @Inject() (
               case None        => form
               case Some(value) => form.fill(value)
             }
-
             Ok(view(preparedForm, lrn, additionalReferences.values, mode, itemIndex, additionalReferenceIndex))
         }
     }

--- a/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
+++ b/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
@@ -26,7 +26,7 @@ import javax.inject.Inject
 
 class AdditionalReferenceNumberFormProvider @Inject() (implicit phaseConfig: PhaseConfig) extends Mappings {
 
-  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String], isDocumentInCL234: Option[Boolean], phase: Phase): Form[String] =
+  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String], isDocumentInCL234: Boolean, phase: Phase): Form[String] =
     Form(
       "value" -> text(s"$prefix.error.required")
         .verifying(
@@ -34,7 +34,7 @@ class AdditionalReferenceNumberFormProvider @Inject() (implicit phaseConfig: Pha
             regexp(stringFieldRegexComma, s"$prefix.error.invalidCharacters"),
             maxLength(phaseConfig.maxAdditionalReferenceNumLength, s"$prefix.error.length"),
             notInList(otherAdditionalReferenceNumbers, s"$prefix.error.unique"),
-            cl234Constraint(isDocumentInCL234.getOrElse(false), phase, s"$prefix.error.cl234Constraint")
+            cl234Constraint(isDocumentInCL234, phase, s"$prefix.error.cl234Constraint")
           )
         )
     )

--- a/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
+++ b/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
@@ -18,6 +18,7 @@ package forms.item.additionalReference
 
 import config.PhaseConfig
 import forms.mappings.Mappings
+import models.Phase
 import models.domain.StringFieldRegex.stringFieldRegexComma
 import play.api.data.Form
 
@@ -25,7 +26,7 @@ import javax.inject.Inject
 
 class AdditionalReferenceNumberFormProvider @Inject() (implicit phaseConfig: PhaseConfig) extends Mappings {
 
-  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String], isDocumentInCL234: Option[Boolean]): Form[String] =
+  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String], isDocumentInCL234: Option[Boolean], phase: Phase): Form[String] =
     Form(
       "value" -> text(s"$prefix.error.required")
         .verifying(
@@ -33,7 +34,7 @@ class AdditionalReferenceNumberFormProvider @Inject() (implicit phaseConfig: Pha
             regexp(stringFieldRegexComma, s"$prefix.error.invalidCharacters"),
             maxLength(phaseConfig.maxAdditionalReferenceNumLength, s"$prefix.error.length"),
             notInList(otherAdditionalReferenceNumbers, s"$prefix.error.unique"),
-            cl234Constraint(isDocumentInCL234.getOrElse(false), s"$prefix.error.cl234Constraint")
+            cl234Constraint(isDocumentInCL234.getOrElse(false), phase, s"$prefix.error.cl234Constraint")
           )
         )
     )

--- a/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
+++ b/app/forms/item/additionalReference/AdditionalReferenceNumberFormProvider.scala
@@ -25,14 +25,15 @@ import javax.inject.Inject
 
 class AdditionalReferenceNumberFormProvider @Inject() (implicit phaseConfig: PhaseConfig) extends Mappings {
 
-  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String]): Form[String] =
+  def apply(prefix: String, otherAdditionalReferenceNumbers: Seq[String], isDocumentInCL234: Option[Boolean]): Form[String] =
     Form(
       "value" -> text(s"$prefix.error.required")
         .verifying(
           forms.StopOnFirstFail[String](
             regexp(stringFieldRegexComma, s"$prefix.error.invalidCharacters"),
             maxLength(phaseConfig.maxAdditionalReferenceNumLength, s"$prefix.error.length"),
-            notInList(otherAdditionalReferenceNumbers, s"$prefix.error.unique")
+            notInList(otherAdditionalReferenceNumbers, s"$prefix.error.unique"),
+            cl234Constraint(isDocumentInCL234.getOrElse(false), s"$prefix.error.cl234Constraint")
           )
         )
     )

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -106,4 +106,12 @@ trait Constraints {
       case _ =>
         Invalid(errorKey)
     }
+
+  protected def cl234Constraint(isDocumentInCL234: Boolean, errorKey: String): Constraint[String] =
+    Constraint {
+      case str if !isDocumentInCL234 || !str.equals("0") =>
+        Valid
+      case _ =>
+        Invalid(errorKey)
+    }
 }

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -16,6 +16,8 @@
 
 package forms.mappings
 
+import models.Phase
+import models.Phase.PostTransition
 import play.api.data.validation.{Constraint, Invalid, Valid}
 
 import java.time.LocalDate
@@ -107,9 +109,9 @@ trait Constraints {
         Invalid(errorKey)
     }
 
-  protected def cl234Constraint(isDocumentInCL234: Boolean, errorKey: String): Constraint[String] =
+  protected def cl234Constraint(isDocumentInCL234: Boolean, phase: Phase, errorKey: String): Constraint[String] =
     Constraint {
-      case str if !isDocumentInCL234 || !str.equals("0") =>
+      case str if !isDocumentInCL234 || !str.equals("0") || phase != PostTransition =>
         Valid
       case _ =>
         Invalid(errorKey)

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -111,9 +111,9 @@ trait Constraints {
 
   protected def cl234Constraint(isDocumentInCL234: Boolean, phase: Phase, errorKey: String): Constraint[String] =
     Constraint {
-      case str if !isDocumentInCL234 || !str.equals("0") || phase != PostTransition =>
-        Valid
-      case _ =>
+      case "0" if isDocumentInCL234 && phase == PostTransition =>
         Invalid(errorKey)
+      case _ =>
+        Valid
     }
 }

--- a/app/models/reference/DocTypeExcise.scala
+++ b/app/models/reference/DocTypeExcise.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+
+import cats.Order
+import play.api.libs.json.{Json, OFormat}
+
+case class DocTypeExcise(activeFrom: String, code: String, state: String, description: String)
+
+object DocTypeExcise {
+  implicit val format: OFormat[DocTypeExcise] = Json.format[DocTypeExcise]
+
+  implicit val order: Order[DocTypeExcise] = (x: DocTypeExcise, y: DocTypeExcise) => {
+    (x, y).compareBy(_.code)
+  }
+}

--- a/app/pages/item/additionalReference/index/AdditionalReferencePage.scala
+++ b/app/pages/item/additionalReference/index/AdditionalReferencePage.scala
@@ -45,3 +45,10 @@ case class AdditionalReferencePage(itemIndex: Index, additionalReferenceIndex: I
         super.cleanup(value, userAnswers)
     }
 }
+
+case class AdditionalReferenceInCL234Page(itemIndex: Index, additionalReferenceIndex: Index) extends QuestionPage[Boolean] {
+
+  override def path: JsPath = AdditionalReferencePage(itemIndex, additionalReferenceIndex).path \ toString
+
+  override def toString: String = "isInCL234"
+}

--- a/app/services/AdditionalReferencesService.scala
+++ b/app/services/AdditionalReferencesService.scala
@@ -17,6 +17,7 @@
 package services
 
 import connectors.ReferenceDataConnector
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import models.SelectableList
 import models.reference.AdditionalReference
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,4 +31,14 @@ class AdditionalReferencesService @Inject() (referenceDataConnector: ReferenceDa
     referenceDataConnector
       .getAdditionalReferences()
       .map(SelectableList(_))
+
+  def isDocumentTypeExcise(docType: String)(implicit hc: HeaderCarrier): Future[Boolean] =
+    referenceDataConnector
+      .getDocumentTypeExcise(docType)
+      .map {
+        _ => true
+      }
+      .recover {
+        case _: NoReferenceDataFoundException => false
+      }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -366,6 +366,7 @@ item.additionalReference.index.additionalReferenceNumber.error.required = Enter 
 item.additionalReference.index.additionalReferenceNumber.error.length = The additional reference number must be {0} characters or less
 item.additionalReference.index.additionalReferenceNumber.error.invalidCharacters = The additional reference number must only include letters a to z without accents, numbers 0 to 9, ampersands (&), apostrophes, at signs (@), commas, forward slashes, full stops, hyphens, question marks and spaces
 item.additionalReference.index.additionalReferenceNumber.error.unique = The additional reference number must be unique
+item.additionalReference.index.additionalReferenceNumber.error.cl234Constraint = The additional reference number must be 1 or more
 
 item.additionalReference.addAnotherAdditionalReference.singular.title = You have added 1 additional reference
 item.additionalReference.addAnotherAdditionalReference.singular.heading = You have added 1 additional reference

--- a/it/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/it/test/connectors/ReferenceDataConnectorSpec.scala
@@ -249,6 +249,36 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
       |}
       |""".stripMargin
 
+  private val documentTypeExciseJson: String =
+    """
+      |{
+      |  "_links": {
+      |    "self": {
+      |      "href": "/customs-reference-data/lists/DocumentTypeExcise"
+      |    }
+      |  },
+      |  "meta": {
+      |    "version": "fb16648c-ea06-431e-bbf6-483dc9ebed6e",
+      |    "snapshotDate": "2023-01-01"
+      |  },
+      |  "id": "DocumentTypeExcise",
+      |  "data": [
+      |  {
+      |    "activeFrom": "2024-01-01",
+      |    "code": "C651",
+      |    "state": "valid",
+      |    "description": "AAD - Administrative Accompanying Document (EMCS)"
+      |  },
+      |  {
+      |    "activeFrom": "2024-01-01",
+      |    "code": "C658",
+      |    "state": "valid",
+      |    "description": "FAD - Fallback e-AD (EMCS)"
+      |  }
+      |]
+      |}
+      |""".stripMargin
+
   private val emptyResponseJson: String =
     """
       |{
@@ -271,6 +301,22 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
         val expectedResult = CUSCode(cusCode)
 
         connector.getCUSCode(cusCode).futureValue mustEqual expectedResult
+      }
+    }
+
+    "getDocumentTypeExcise" - {
+      val code = "C651"
+      val url = s"/$baseUrl/lists/DocumentTypeExcise?data.code=$code"
+
+      "must return DocumentTypeExcise when successful" in {
+        server.stubFor(
+          get(urlEqualTo(url))
+            .willReturn(okJson(documentTypeExciseJson))
+        )
+
+        val expectedResult = DocTypeExcise(activeFrom = "2024-01-01", code = "C651", state = "valid", description = "AAD - Administrative Accompanying Document (EMCS)")
+
+        connector.getDocumentTypeExcise(code).futureValue mustEqual expectedResult
       }
     }
 

--- a/test/controllers/item/additionalReference/index/AdditionalReferenceControllerSpec.scala
+++ b/test/controllers/item/additionalReference/index/AdditionalReferenceControllerSpec.scala
@@ -57,6 +57,7 @@ class AdditionalReferenceControllerSpec extends SpecBase with AppWithDefaultMock
     "must return OK and the correct view for a GET" in {
 
       when(mockAdditionalReferencesService.getAdditionalReferences()(any())).thenReturn(Future.successful(additionalReferenceList))
+      when(mockAdditionalReferencesService.isDocumentTypeExcise(any())(any())).thenReturn(Future.successful(false))
       setExistingUserAnswers(emptyUserAnswers)
 
       val request = FakeRequest(GET, additionalReferenceRoute)
@@ -74,6 +75,7 @@ class AdditionalReferenceControllerSpec extends SpecBase with AppWithDefaultMock
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       when(mockAdditionalReferencesService.getAdditionalReferences()(any())).thenReturn(Future.successful(additionalReferenceList))
+      when(mockAdditionalReferencesService.isDocumentTypeExcise(any())(any())).thenReturn(Future.successful(false))
       val userAnswers = emptyUserAnswers.setValue(AdditionalReferencePage(itemIndex, additionalReferenceIndex), additionalReference1)
       setExistingUserAnswers(userAnswers)
 
@@ -111,6 +113,7 @@ class AdditionalReferenceControllerSpec extends SpecBase with AppWithDefaultMock
     "must return a Bad Request and errors when invalid data is submitted" in {
 
       when(mockAdditionalReferencesService.getAdditionalReferences()(any())).thenReturn(Future.successful(additionalReferenceList))
+      when(mockAdditionalReferencesService.isDocumentTypeExcise(any())(any())).thenReturn(Future.successful(false))
       setExistingUserAnswers(emptyUserAnswers)
 
       val request   = FakeRequest(POST, additionalReferenceRoute).withFormUrlEncodedBody(("value", "invalid value"))

--- a/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
+++ b/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers.item.additionalReference.index
 import base.{AppWithDefaultMockFixtures, SpecBase}
 import forms.item.additionalReference.AdditionalReferenceNumberFormProvider
 import generators.Generators
+import models.Phase.Transition
 import models.reference.AdditionalReference
 import models.{NormalMode, UserAnswers}
 import navigation.AdditionalReferenceNavigatorProvider
@@ -41,8 +42,10 @@ class AdditionalReferenceNumberControllerSpec extends SpecBase with AppWithDefau
 
   private val viewModel = arbitrary[AdditionalReferenceNumberViewModel].sample.value
 
-  private lazy val formProvider                   = new AdditionalReferenceNumberFormProvider()
-  private lazy val form                           = formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers, Some(false))
+  private lazy val formProvider = new AdditionalReferenceNumberFormProvider()
+
+  private lazy val form =
+    formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers, Some(false), Transition)
   private val mode                                = NormalMode
   private lazy val additionalReferenceNumberRoute = routes.AdditionalReferenceNumberController.onPageLoad(lrn, mode, itemIndex, additionalReferenceIndex).url
 

--- a/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
+++ b/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
@@ -27,7 +27,12 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalacheck.Arbitrary.arbitrary
-import pages.item.additionalReference.index.{AddAdditionalReferenceNumberYesNoPage, AdditionalReferenceNumberPage, AdditionalReferencePage}
+import pages.item.additionalReference.index.{
+  AddAdditionalReferenceNumberYesNoPage,
+  AdditionalReferenceInCL234Page,
+  AdditionalReferenceNumberPage,
+  AdditionalReferencePage
+}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
@@ -45,7 +50,7 @@ class AdditionalReferenceNumberControllerSpec extends SpecBase with AppWithDefau
   private lazy val formProvider = new AdditionalReferenceNumberFormProvider()
 
   private lazy val form =
-    formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers, Some(false), Transition)
+    formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers, isDocumentInCL234 = false, Transition)
   private val mode                                = NormalMode
   private lazy val additionalReferenceNumberRoute = routes.AdditionalReferenceNumberController.onPageLoad(lrn, mode, itemIndex, additionalReferenceIndex).url
 
@@ -59,7 +64,10 @@ class AdditionalReferenceNumberControllerSpec extends SpecBase with AppWithDefau
 
   private val additionalReference = arbitrary[AdditionalReference].sample.value
 
-  private val baseAnswers = emptyUserAnswers.setValue(AdditionalReferencePage(itemIndex, additionalReferenceIndex), additionalReference)
+  private val baseAnswers =
+    emptyUserAnswers
+      .setValue(AdditionalReferencePage(itemIndex, additionalReferenceIndex), additionalReference)
+      .setValue(AdditionalReferenceInCL234Page(itemIndex, additionalReferenceIndex), false)
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
+++ b/test/controllers/item/additionalReference/index/AdditionalReferenceNumberControllerSpec.scala
@@ -42,7 +42,7 @@ class AdditionalReferenceNumberControllerSpec extends SpecBase with AppWithDefau
   private val viewModel = arbitrary[AdditionalReferenceNumberViewModel].sample.value
 
   private lazy val formProvider                   = new AdditionalReferenceNumberFormProvider()
-  private lazy val form                           = formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers)
+  private lazy val form                           = formProvider("item.additionalReference.index.additionalReferenceNumber", viewModel.otherAdditionalReferenceNumbers, Some(false))
   private val mode                                = NormalMode
   private lazy val additionalReferenceNumberRoute = routes.AdditionalReferenceNumberController.onPageLoad(lrn, mode, itemIndex, additionalReferenceIndex).url
 

--- a/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
+++ b/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
@@ -81,7 +81,7 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
     "during transition" - {
       val app = transitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true), Transition)
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, isDocumentInCL234 = true, Transition)
         runTests(form, maxAdditionalReferenceNumTransitionLength)
       }
     }
@@ -92,7 +92,7 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
 
       val app = postTransitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true), PostTransition)
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, isDocumentInCL234 = true, PostTransition)
         runTests(form, maxAdditionalReferenceNumPostTransitionLength)
 
         behave like fieldWithInvalidInputCL234(

--- a/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
+++ b/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
@@ -31,6 +31,7 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
   private val invalidKey  = s"$prefix.error.invalidCharacters"
   private val lengthKey   = s"$prefix.error.length"
   private val uniqueKey   = s"$prefix.error.unique"
+  private val cl234Key    = s"$prefix.error.cl234Constraint"
 
   private val values = listWithMaxLength[String]()(Arbitrary(nonEmptyString)).sample.value
 
@@ -79,16 +80,26 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
     "during transition" - {
       val app = transitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values)
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(false))
         runTests(form, maxAdditionalReferenceNumTransitionLength)
       }
     }
 
     "post transition" - {
+
+      val fieldName = "value"
+
       val app = postTransitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values)
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true))
         runTests(form, maxAdditionalReferenceNumPostTransitionLength)
+
+        behave like fieldWithInvalidInputCL234(
+          form,
+          fieldName,
+          error = FormError(fieldName, cl234Key)
+        )
+
       }
     }
   }

--- a/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
+++ b/test/forms/AdditionalReferenceNumberFormProviderSpec.scala
@@ -19,6 +19,7 @@ package forms
 import base.{AppWithDefaultMockFixtures, SpecBase}
 import forms.behaviours.StringFieldBehaviours
 import forms.item.additionalReference.AdditionalReferenceNumberFormProvider
+import models.Phase.{PostTransition, Transition}
 import models.domain.StringFieldRegex.stringFieldRegexComma
 import org.scalacheck.{Arbitrary, Gen}
 import play.api.data.{Form, FormError}
@@ -80,7 +81,7 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
     "during transition" - {
       val app = transitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(false))
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true), Transition)
         runTests(form, maxAdditionalReferenceNumTransitionLength)
       }
     }
@@ -91,7 +92,7 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
 
       val app = postTransitionApplicationBuilder().build()
       running(app) {
-        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true))
+        val form = app.injector.instanceOf[AdditionalReferenceNumberFormProvider].apply(prefix, values, Some(true), PostTransition)
         runTests(form, maxAdditionalReferenceNumPostTransitionLength)
 
         behave like fieldWithInvalidInputCL234(
@@ -99,7 +100,6 @@ class AdditionalReferenceNumberFormProviderSpec extends SpecBase with AppWithDef
           fieldName,
           error = FormError(fieldName, cl234Key)
         )
-
       }
     }
   }

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -70,6 +70,13 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
 
+  def fieldWithInvalidInputCL234(form: Form[_], fieldName: String, error: FormError): Unit =
+    "must not bind strings with value '0' when in CL234" in {
+
+      val result: Field = form.bind(Map(fieldName -> "0")).apply(fieldName)
+      result.errors must contain(error)
+    }
+
   def fieldThatBindsUniqueData(form: Form[_], fieldName: String, values: Seq[String], uniqueError: FormError): Unit = {
 
     "bind unique data" in {

--- a/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
+++ b/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
@@ -35,7 +35,7 @@ class AdditionalReferenceNumberViewSpec extends SpecBase with CharacterCountView
 
   private val formProvider = new AdditionalReferenceNumberFormProvider()(phaseConfig)
 
-  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers, Some(false))
+  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers, Some(false), phaseConfig.phase)
 
   override def applyView(form: Form[String]): HtmlFormat.Appendable =
     injector

--- a/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
+++ b/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
@@ -35,7 +35,7 @@ class AdditionalReferenceNumberViewSpec extends SpecBase with CharacterCountView
 
   private val formProvider = new AdditionalReferenceNumberFormProvider()(phaseConfig)
 
-  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers)
+  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers, Some(false))
 
   override def applyView(form: Form[String]): HtmlFormat.Appendable =
     injector

--- a/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
+++ b/test/views/item/additionalReference/index/AdditionalReferenceNumberViewSpec.scala
@@ -35,7 +35,7 @@ class AdditionalReferenceNumberViewSpec extends SpecBase with CharacterCountView
 
   private val formProvider = new AdditionalReferenceNumberFormProvider()(phaseConfig)
 
-  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers, Some(false), phaseConfig.phase)
+  override def form: Form[String] = formProvider(prefix, viewModel.otherAdditionalReferenceNumbers, isDocumentInCL234 = false, phaseConfig.phase)
 
   override def applyView(form: Form[String]): HtmlFormat.Appendable =
     injector


### PR DESCRIPTION
![Screenshot 2024-05-20 at 14 09 17](https://github.com/hmrc/ctc-departure-items-frontend/assets/12535866/0d3c0553-ebd7-4854-b02c-78cef4ee7f2f)
![Screenshot 2024-05-20 at 14 09 05](https://github.com/hmrc/ctc-departure-items-frontend/assets/12535866/a331cda3-87d9-4458-baba-2b1093bbfcd7)


NOTE: run in post transition mode to see error. `-Dplay.additional.module=config.PostTransitionModule run`
